### PR TITLE
Add new updateEstimatedGlobalPose

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -134,6 +134,7 @@ public final class Constants {
   public static final Matter CHASSIS    = new Matter(new Translation3d(0, 0, Units.inchesToMeters(8)), ROBOT_MASS);
   public static final double LOOP_TIME  = 0.13; //s, 20ms + 110ms sprk max velocity lag
   public static final double MAX_SPEED  = Units.feetToMeters(2);//14.5
+  public static final double MAXIMUM_AMBIGUITY = 0.25;
   // Maximum speed of the robot in meters per second, used to limit acceleration.
 
 //  public static final class AutonConstants

--- a/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
@@ -40,6 +40,7 @@ import org.photonvision.targeting.PhotonPipelineResult;
 import org.photonvision.targeting.PhotonTrackedTarget;
 import swervelib.SwerveDrive;
 import swervelib.telemetry.SwerveDriveTelemetry;
+import frc.robot.Constants;
 
 
 /**
@@ -99,6 +100,10 @@ public class Vision
       addAprilTagPositioning();
       updateRobotVisionPosition(currentPose.get());
     }
+  }
+
+  public List<PhotonPipelineResult> GetFrontTargets() {
+    return Cameras.LEFT_CAM.resultsList;
   }
 
   /**
@@ -392,11 +397,32 @@ public class Vision
     private void updateEstimatedGlobalPose()
     {
       Optional<EstimatedRobotPose> visionEst = Optional.empty();
-      for (var change : resultsList)
-      {
-        visionEst = poseEstimator.update(change);
-        updateEstimationStdDevs(visionEst, change.getTargets());
+            
+      for (var result : resultsList) {
+          // Filter by ambiguity if needed
+          if (result.hasTargets()) {
+              double bestAmbiguity = 1.0;
+              for (PhotonTrackedTarget target : result.getTargets()) {
+                  double ambiguity = target.getPoseAmbiguity();
+                  if (ambiguity != -1 && ambiguity < bestAmbiguity) {
+                      bestAmbiguity = ambiguity;
+                  }
+              }
+              
+              // Skip if ambiguity is too high
+              if (bestAmbiguity > Constants.MAXIMUM_AMBIGUITY) {
+                  continue;
+              }
+          }
+          
+          visionEst = poseEstimator.update(result);
+          
+          if (visionEst.isPresent()) {
+              updateEstimationStdDevs(visionEst, result.getTargets());
+              break; // Use first good result
+          }
       }
+      
       estimatedRobotPose = visionEst;
     }
 


### PR DESCRIPTION
Change the `updateEstimatedGlobalPose` function to find the best result, use that for the pose update and then exit. The goal is to use less CPU by not updating the estimated pose for every target in site. 