### PR TITLE
[DO NOT MERGE WITHOUT TESTING ON BOT] Refactor vision to not use an enum

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -72,23 +72,25 @@ public final class Constants {
 
   // CONTROL CONSTANT CLASSES
 
-  public static class Vision {
-    // public static final String kCameraName = "HD_Webcam_C615";
-    // Cam mounted facing forward, half a meter forward of center, half a meter up
-    // from center.
-    public static final Transform3d kRobotToCam = new Transform3d(new Translation3d(0.127, .3620516, .2397125),
-        new Rotation3d(0, 0, 0));
+  public static class BottomCamera {
+    public static String kName = "bottom";
+    public static Rotation3d kCameraRotation = new Rotation3d(Math.toRadians(0), Math.toRadians(0), Math.toRadians(30));
+    public static Translation3d kCameraOffset = new Translation3d(Units.inchesToMeters(9.25),
+        Units.inchesToMeters(-10.125), Units.inchesToMeters(18));
+    public static Matrix<N3, N1> kSingleTagDeviations = VecBuilder.fill(.9, .9, 6);
+    public static Matrix<N3, N1> kMultiTagDeviation = VecBuilder.fill(0.5, 0.5, 1);
 
-    // The layout of the AprilTags on the field
-    public static final AprilTagFieldLayout kTagLayout = AprilTagFieldLayout
-        .loadField(AprilTagFields.k2025ReefscapeWelded);
+  };
 
-    // The standard deviations of our vision estimated poses, which affect
-    // correction rate
-    // (Fake values. Experiment and determine estimation noise on an actual robot.)
-    public static final Matrix<N3, N1> kSingleTagStdDevs = VecBuilder.fill(4, 4, 8);
-    public static final Matrix<N3, N1> kMultiTagStdDevs = VecBuilder.fill(0.5, 0.5, 1);
-  }
+  public static class TopCamera {
+    public static String kName = "top";
+    public static Rotation3d kCameraRotation = new Rotation3d(0, Math.toRadians(0), Math.toRadians(180));
+    public static Translation3d kCameraOffset = new Translation3d(Units.inchesToMeters(-7), Units.inchesToMeters(0),
+        Units.inchesToMeters(14.75));
+    public static Matrix<N3, N1> kSingleTagDeviations = VecBuilder.fill(1.8, 1.8, 8);
+    public static Matrix<N3, N1> kMultiTagDeviation = VecBuilder.fill(0.5, 0.5, 1);
+
+  };
 
   public static final class AutonConstants {
 

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -42,7 +42,6 @@ import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Config;
 import frc.robot.Constants;
-import frc.robot.subsystems.swervedrive.Vision.Cameras;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -119,7 +118,7 @@ public class SwerveSubsystem extends SubsystemBase {
       File directory) {
     // Configure the Telemetry before creating the SwerveDrive to avoid unnecessary
     // objects being created.
-    SwerveDriveTelemetry.verbosity = TelemetryVerbosity.NONE;
+    SwerveDriveTelemetry.verbosity = TelemetryVerbosity.HIGH;
     try {
       swerveDrive = new SwerveParser(directory).createSwerveDrive(Constants.MAX_SPEED,
           new Pose2d(new Translation2d(Meter.of(1),
@@ -244,7 +243,6 @@ public class SwerveSubsystem extends SubsystemBase {
   public double rotspeed;
   public double alliancered;
 
-
   @Override
   public void periodic() {
     // if (vision.numTags == 0) {
@@ -257,7 +255,6 @@ public class SwerveSubsystem extends SubsystemBase {
     swerveDrive.updateOdometry();
     vision.updatePoseEstimation(swerveDrive);
     // vision.updateVisionField(swerveDrive);
-     
 
     // Use the triggers to control the robot actions
     if ((LeftTrigger.getAsBoolean() || RightTrigger.getAsBoolean() || RightBumper.getAsBoolean()
@@ -271,195 +268,194 @@ public class SwerveSubsystem extends SubsystemBase {
     if (!LeftTrigger.getAsBoolean() && !RightTrigger.getAsBoolean() && !RightBumper.getAsBoolean()
         && !LeftBumper.getAsBoolean()) {
       run = false;
-        closestTagId = -1;
+      closestTagId = -1;
     }
     SmartDashboard.putNumber("Closest Tag", closestTagId);
     if (alliance.isPresent()) {
       Alliance currentAlliance = alliance.get();
 
       if (currentAlliance == Alliance.Red) {
-      driveToRedPose();
-      alliancered=-1;
+        driveToRedPose();
+        alliancered = -1;
       } else if (currentAlliance == Alliance.Blue) {
-      driveToBluePose();
-      alliancered=1;
+        driveToBluePose();
+        alliancered = 1;
       } else {
-      System.out.println("Alliance color not determined yet.");
+        System.out.println("Alliance color not determined yet.");
       }
     }
     if (LeftTrigger.getAsBoolean() || RightTrigger.getAsBoolean()) {
-    xSpeed=  alliancered*ySpeedOutput;
-    ySpeed=alliancered*xSpeedOutput;
-    rotspeed = rotationSpeedOutput;
-    }
-    else{
-      xSpeed=-driverXbox.getLeftX();
-      ySpeed=-driverXbox.getLeftY();
+      xSpeed = alliancered * ySpeedOutput;
+      ySpeed = alliancered * xSpeedOutput;
+      rotspeed = rotationSpeedOutput;
+    } else {
+      xSpeed = -driverXbox.getLeftX();
+      ySpeed = -driverXbox.getLeftY();
       rotspeed = -driverXbox.getRightX();
     }
   }
 
-    public void driveToRedPose() {
+  public void driveToRedPose() {
     // closestTagId = 6;
     if (closestTagId == 7) {
       if (LeftTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(14.380, 3.852), Rotation2d.fromDegrees(180)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(14.380, 3.852), Rotation2d.fromDegrees(180)));
       }
       if (RightTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(14.395, 4.168), Rotation2d.fromDegrees(180)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(14.395, 4.168), Rotation2d.fromDegrees(180)));
       }
     }
 
     else if (closestTagId == 8) {
       if (LeftTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(13.869, 5.099), Rotation2d.fromDegrees(-120)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(13.869, 5.099), Rotation2d.fromDegrees(-120)));
       }
       if (RightTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(13.583, 5.265), Rotation2d.fromDegrees(-120)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(13.583, 5.265), Rotation2d.fromDegrees(-120)));
       }
     }
 
     else if (closestTagId == 9) {
       if (LeftTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(12.516, 5.280), Rotation2d.fromDegrees(-60)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(12.516, 5.280), Rotation2d.fromDegrees(-60)));
       }
       if (RightTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(12.201, 5.099), Rotation2d.fromDegrees(-60)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(12.201, 5.099), Rotation2d.fromDegrees(-60)));
       }
     }
 
     else if (closestTagId == 10) {
       if (LeftTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(11.735, 4.183), Rotation2d.fromDegrees(0)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(11.735, 4.183), Rotation2d.fromDegrees(0)));
       }
       if (RightTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(11.750, 3.852), Rotation2d.fromDegrees(0)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(11.750, 3.852), Rotation2d.fromDegrees(0)));
       }
     }
 
     else if (closestTagId == 11) {
       if (LeftTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(12.231, 2.966), Rotation2d.fromDegrees(60)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(12.231, 2.966), Rotation2d.fromDegrees(60)));
       }
       if (RightTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(12.546, 2.815), Rotation2d.fromDegrees(60)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(12.546, 2.815), Rotation2d.fromDegrees(60)));
       }
     }
 
     else if (closestTagId == 6) {
       if (LeftTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(13.568, 2.755), Rotation2d.fromDegrees(120)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(13.568, 2.755), Rotation2d.fromDegrees(120)));
       }
       if (RightTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(13.869, 2.951), Rotation2d.fromDegrees(120)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(13.869, 2.951), Rotation2d.fromDegrees(120)));
       }
     }
 
     else if (closestTagId == 1) {
       if (LeftBumper.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(16.844, 1.358), Rotation2d.fromDegrees(-55)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(16.844, 1.358), Rotation2d.fromDegrees(-55)));
       }
       if (RightBumper.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(15.942, 0.682), Rotation2d.fromDegrees(-55)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(15.942, 0.682), Rotation2d.fromDegrees(-55)));
       }
     }
 
     else if (closestTagId == 2) {
       if (LeftBumper.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(16.799, 6.704), Rotation2d.fromDegrees(55)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(16.799, 6.704), Rotation2d.fromDegrees(55)));
       }
       if (RightBumper.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(15.897, 7.353), Rotation2d.fromDegrees(55)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(15.897, 7.353), Rotation2d.fromDegrees(55)));
       }
     }
-    }
+  }
 
-    public void driveToBluePose() {
+  public void driveToBluePose() {
     if (closestTagId == 19) {
       if (LeftTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(3.630, 5.088), Rotation2d.fromDegrees(-60)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(3.630, 5.088), Rotation2d.fromDegrees(-60)));
       }
       if (RightTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(3.927, 5.309), Rotation2d.fromDegrees(-60)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(3.927, 5.309), Rotation2d.fromDegrees(-60)));
       }
     }
 
     else if (closestTagId == 20) {
       if (LeftTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(5.019, 5.272), Rotation2d.fromDegrees(-120)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(5.019, 5.272), Rotation2d.fromDegrees(-120)));
       }
       if (RightTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(5.294, 5.088), Rotation2d.fromDegrees(-120)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(5.294, 5.088), Rotation2d.fromDegrees(-120)));
       }
     }
 
     else if (closestTagId == 21) {
       if (LeftTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(5.813, 4.181), Rotation2d.fromDegrees(180)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(5.813, 4.181), Rotation2d.fromDegrees(180)));
       }
       if (RightTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(5.841, 3.827), Rotation2d.fromDegrees(180)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(5.841, 3.827), Rotation2d.fromDegrees(180)));
       }
     }
 
     else if (closestTagId == 22) {
       if (LeftTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(5.294, 2.990), Rotation2d.fromDegrees(120)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(5.294, 2.990), Rotation2d.fromDegrees(120)));
       }
       if (RightTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(5.019, 2.806), Rotation2d.fromDegrees(120)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(5.019, 2.806), Rotation2d.fromDegrees(120)));
       }
     }
 
     else if (closestTagId == 17) {
       if (LeftTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(3.956, 2.806), Rotation2d.fromDegrees(60)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(3.956, 2.806), Rotation2d.fromDegrees(60)));
       }
       if (RightTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(3.673, 2.976), Rotation2d.fromDegrees(60)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(3.673, 2.976), Rotation2d.fromDegrees(60)));
       }
     }
 
     else if (closestTagId == 18) {
       if (LeftTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(3.177, 4.167), Rotation2d.fromDegrees(0)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(3.177, 4.167), Rotation2d.fromDegrees(0)));
       }
       if (RightTrigger.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(3.177, 3.855), Rotation2d.fromDegrees(0)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(3.177, 3.855), Rotation2d.fromDegrees(0)));
       }
     }
 
     else if (closestTagId == 12) {
       if (LeftBumper.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(1.816, 0.595), Rotation2d.fromDegrees(-125)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(1.816, 0.595), Rotation2d.fromDegrees(-125)));
       }
       if (RightBumper.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(1.023, 1.162), Rotation2d.fromDegrees(-125)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(1.023, 1.162), Rotation2d.fromDegrees(-125)));
       }
     }
 
     else if (closestTagId == 13) {
       if (LeftBumper.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(1.632, 7.313), Rotation2d.fromDegrees(125)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(1.632, 7.313), Rotation2d.fromDegrees(125)));
       }
       if (RightBumper.getAsBoolean()) {
-      calculatePIDOutputs(new Pose2d(new Translation2d(0.782, 6.704), Rotation2d.fromDegrees(125)));
+        calculatePIDOutputs(new Pose2d(new Translation2d(0.782, 6.704), Rotation2d.fromDegrees(125)));
       }
     }
 
-    }
+  }
 
-    // PID controllers for X, Y, and Rotation
-    private final PIDController xController = new PIDController(1.8, 0.00, .001);
-    private final PIDController yController = new PIDController(1.8, 0.0, .001);
-    private final PIDController rotationController = new PIDController(0.3, 0.0, 001);
-    Timer timer = new Timer();
-    private boolean isDrivingToPose = false;
-    public double xSpeedOutput;
-    public double ySpeedOutput;
-    public double rotationSpeedOutput;
+  // PID controllers for X, Y, and Rotation
+  private final PIDController xController = new PIDController(1.8, 0.00, .001);
+  private final PIDController yController = new PIDController(1.8, 0.0, .001);
+  private final PIDController rotationController = new PIDController(0.3, 0.0, 001);
+  Timer timer = new Timer();
+  private boolean isDrivingToPose = false;
+  public double xSpeedOutput;
+  public double ySpeedOutput;
+  public double rotationSpeedOutput;
 
-    private void calculatePIDOutputs(Pose2d targetPose) {
+  private void calculatePIDOutputs(Pose2d targetPose) {
 
     Pose2d currentPose = getPose();
 
@@ -467,7 +463,7 @@ public class SwerveSubsystem extends SubsystemBase {
     double xSpeed = xController.calculate(currentPose.getX(), targetPose.getX());
     double ySpeed = yController.calculate(currentPose.getY(), targetPose.getY());
     double rotationSpeed = rotationController.calculate(currentPose.getRotation().getRadians(),
-      targetPose.getRotation().getRadians());
+        targetPose.getRotation().getRadians());
 
     // Normalize speeds if necessary
     double maxAbsSpeed = Math.max(Math.max(Math.abs(xSpeed), Math.abs(ySpeed)), Math.abs(rotationSpeed));
@@ -476,20 +472,20 @@ public class SwerveSubsystem extends SubsystemBase {
       ySpeed /= maxAbsSpeed;
       rotationSpeed /= maxAbsSpeed;
     }
-    if (xSpeed<-.5){
-      xSpeed=-.5;
+    if (xSpeed < -.5) {
+      xSpeed = -.5;
 
     }
-    if (ySpeed<-.5){
-      ySpeed=-.5;
+    if (ySpeed < -.5) {
+      ySpeed = -.5;
 
     }
-    if (xSpeed>.5){
-      xSpeed=.5;
+    if (xSpeed > .5) {
+      xSpeed = .5;
 
     }
-    if (ySpeed>.5){
-      ySpeed=.5;
+    if (ySpeed > .5) {
+      ySpeed = .5;
 
     }
 
@@ -508,10 +504,10 @@ public class SwerveSubsystem extends SubsystemBase {
     if (positionError < 0.1 && angleError < 0.1) {
       isDrivingToPose = false;
     }
-    }
+  }
 
-    @Override
-    public void simulationPeriodic() {
+  @Override
+  public void simulationPeriodic() {
     vision.updatePoseEstimation(swerveDrive);
     vision.visionSim.update(swerveDrive.getPose());
     // findClosestAprilTag();
@@ -583,27 +579,6 @@ public class SwerveSubsystem extends SubsystemBase {
     // Preload PathPlanner Path finding
     // IF USING CUSTOM PATHFINDER ADD BEFORE THIS LINE
     PathfindingCommand.warmupCommand().schedule();
-  }
-
-  /**
-   * Aim the robot at the target returned by PhotonVision.
-   *
-   * @return A {@link Command} which will run the alignment.
-   */
-  public Command aimAtTarget(Cameras camera) {
-
-    return run(() -> {
-      Optional<PhotonPipelineResult> resultO = camera.getBestResult();
-      if (resultO.isPresent()) {
-        var result = resultO.get();
-        if (result.hasTargets()) {
-          drive(getTargetSpeeds(0,
-              0,
-              Rotation2d.fromDegrees(result.getBestTarget()
-                  .getYaw()))); // Not sure if this will work, more math may be required.
-        }
-      }
-    });
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
@@ -1,26 +1,10 @@
 package frc.robot.subsystems.swervedrive;
 
-import static edu.wpi.first.units.Units.Microseconds;
-import static edu.wpi.first.units.Units.Milliseconds;
-import static edu.wpi.first.units.Units.Seconds;
-
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
-import edu.wpi.first.math.Matrix;
-import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform2d;
-import edu.wpi.first.math.geometry.Transform3d;
-import edu.wpi.first.math.geometry.Translation3d;
-import edu.wpi.first.math.numbers.N1;
-import edu.wpi.first.math.numbers.N3;
-import edu.wpi.first.math.util.Units;
-import edu.wpi.first.networktables.NetworkTablesJNI;
-import edu.wpi.first.wpilibj.Alert;
-import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import frc.robot.Constants;
 import frc.robot.Robot;
@@ -30,12 +14,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.photonvision.EstimatedRobotPose;
-import org.photonvision.PhotonCamera;
-import org.photonvision.PhotonPoseEstimator;
-import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 import org.photonvision.PhotonUtils;
-import org.photonvision.simulation.PhotonCameraSim;
-import org.photonvision.simulation.SimCameraProperties;
 import org.photonvision.simulation.VisionSystemSim;
 import org.photonvision.targeting.PhotonPipelineResult;
 import org.photonvision.targeting.PhotonTrackedTarget;
@@ -43,13 +22,13 @@ import swervelib.SwerveDrive;
 import swervelib.telemetry.SwerveDriveTelemetry;
 import frc.robot.subsystems.led.LED;
 
-/**
- * Example PhotonVision class to aid in the pursuit of accurate odometry. Taken
- * from
- * https://gitlab.com/ironclad_code/ironclad-2024/-/blob/master/src/main/java/frc/robot/vision/Vision.java?ref_type=heads
- */
 public class Vision {
 
+  /**
+   * Instance of the LED subsystem created in RobotContainer.
+   * We keep passing it down so there's only one instance
+   * and we can track state
+   */
   public static LED m_ledSubsystem;
 
   /**
@@ -58,19 +37,9 @@ public class Vision {
   public static final AprilTagFieldLayout fieldLayout = AprilTagFieldLayout.loadField(
       AprilTagFields.k2025ReefscapeAndyMark);
   /**
-   * Ambiguity defined as a value between (0,1). Used in
-   * {@link Vision#filterPose}.
-   */
-  private final double maximumAmbiguity = 0.25;
-  /**
    * Photon Vision Simulation
    */
   public VisionSystemSim visionSim;
-  /**
-   * Count of times that the odom thinks we're more than 10meters away from the
-   * april tag.
-   */
-  private double longDistangePoseEstimationCount = 0;
   /**
    * Current pose from the pose estimator using wheel odometry.
    */
@@ -80,6 +49,8 @@ public class Vision {
    * Field from {@link swervelib.SwerveDrive#field}
    */
   private Field2d field2d;
+
+  private VisionCamera[] Cameras;
 
   /**
    * Constructor for the Vision class.
@@ -92,14 +63,32 @@ public class Vision {
     this.currentPose = currentPose;
     this.field2d = field;
     m_ledSubsystem = new LED();
-    for (Cameras c : Cameras.values()) {
-      System.out.printf("Camera: %s\n", c.name());
-    }
+
+    VisionCamera bottomCamera = new VisionCamera(
+        Constants.BottomCamera.kName,
+        Constants.BottomCamera.kCameraRotation,
+        Constants.BottomCamera.kCameraOffset,
+        Constants.BottomCamera.kSingleTagDeviations,
+        Constants.BottomCamera.kMultiTagDeviation,
+        m_ledSubsystem);
+
+    VisionCamera topCamera = new VisionCamera(
+        Constants.TopCamera.kName,
+        Constants.TopCamera.kCameraRotation,
+        Constants.TopCamera.kCameraOffset,
+        Constants.TopCamera.kSingleTagDeviations,
+        Constants.TopCamera.kMultiTagDeviation,
+        m_ledSubsystem);
+
+    Cameras = new VisionCamera[] {
+        bottomCamera,
+        topCamera
+    };
     if (Robot.isSimulation()) {
       visionSim = new VisionSystemSim("Vision");
       visionSim.addAprilTags(fieldLayout);
 
-      for (Cameras c : Cameras.values()) {
+      for (VisionCamera c : Cameras) {
         c.addToVisionSim(visionSim);
       }
 
@@ -146,7 +135,7 @@ public class Vision {
        */
       visionSim.update(swerveDrive.getSimulationDriveTrainPose().get());
     }
-    for (Cameras camera : Cameras.values()) {
+    for (VisionCamera camera : Cameras) {
       Optional<EstimatedRobotPose> poseEst = getEstimatedGlobalPose(camera);
       if (poseEst.isPresent()) {
         var pose = poseEst.get();
@@ -168,7 +157,7 @@ public class Vision {
    * @return an {@link EstimatedRobotPose} with an estimated pose, timestamp, and
    *         targets used to create the estimate
    */
-  public Optional<EstimatedRobotPose> getEstimatedGlobalPose(Cameras camera) {
+  public Optional<EstimatedRobotPose> getEstimatedGlobalPose(VisionCamera camera) {
     Optional<EstimatedRobotPose> poseEst = camera.getEstimatedGlobalPose();
     if (Robot.isSimulation()) {
       Field2d debugField = visionSim.getDebugField();
@@ -185,47 +174,6 @@ public class Vision {
   }
 
   /**
-   * Filter pose via the ambiguity and find best estimate between all of the
-   * camera's throwing out distances more than
-   * 10m for a short amount of time.
-   *
-   * @param pose Estimated robot pose.
-   * @return Could be empty if there isn't a good reading.
-   */
-  @Deprecated(since = "2024", forRemoval = true)
-  private Optional<EstimatedRobotPose> filterPose(Optional<EstimatedRobotPose> pose) {
-    if (pose.isPresent()) {
-      double bestTargetAmbiguity = 1; // 1 is max ambiguity
-      for (PhotonTrackedTarget target : pose.get().targetsUsed) {
-        double ambiguity = target.getPoseAmbiguity();
-        if (ambiguity != -1 && ambiguity < bestTargetAmbiguity) {
-          bestTargetAmbiguity = ambiguity;
-        }
-      }
-      // ambiguity to high dont use estimate
-      if (bestTargetAmbiguity > maximumAmbiguity) {
-        return Optional.empty();
-      }
-
-      // est pose is very far from recorded robot pose
-      if (PhotonUtils.getDistanceToPose(currentPose.get(), pose.get().estimatedPose.toPose2d()) > 1) {
-        longDistangePoseEstimationCount++;
-
-        // if it calculates that were 10 meter away for more than 10 times in a row its
-        // probably right
-        if (longDistangePoseEstimationCount < 10) {
-          return Optional.empty();
-        }
-      } else {
-        longDistangePoseEstimationCount = 0;
-      }
-      return pose;
-    }
-    return Optional.empty();
-
-  }
-
-  /**
    * Get distance of the robot from the AprilTag pose.
    *
    * @param id AprilTag ID
@@ -234,28 +182,6 @@ public class Vision {
   public double getDistanceFromAprilTag(int id) {
     Optional<Pose3d> tag = fieldLayout.getTagPose(id);
     return tag.map(pose3d -> PhotonUtils.getDistanceToPose(currentPose.get(), pose3d.toPose2d())).orElse(-1.0);
-  }
-
-  /**
-   * Get tracked target from a camera of AprilTagID
-   *
-   * @param id     AprilTag ID
-   * @param camera Camera to check.
-   * @return Tracked target.
-   */
-  public PhotonTrackedTarget getTargetFromId(int id, Cameras camera) {
-    PhotonTrackedTarget target = null;
-    for (PhotonPipelineResult result : camera.resultsList) {
-      if (result.hasTargets()) {
-        for (PhotonTrackedTarget i : result.getTargets()) {
-          if (i.getFiducialId() == id) {
-            return i;
-          }
-        }
-      }
-    }
-    return target;
-
   }
 
   /**
@@ -291,7 +217,7 @@ public class Vision {
   public void updateVisionField() {
 
     List<PhotonTrackedTarget> targets = new ArrayList<PhotonTrackedTarget>();
-    for (Cameras c : Cameras.values()) {
+    for (VisionCamera c : Cameras) {
       if (!c.resultsList.isEmpty()) {
         PhotonPipelineResult latest = c.resultsList.get(0);
         if (latest.hasTargets()) {
@@ -309,317 +235,6 @@ public class Vision {
     }
 
     field2d.getObject("tracked targets").setPoses(poses);
-  }
-
-  /**
-   * Camera Enum to select each camera
-   */
-  enum Cameras {
-    LEFT_CAM("bottom", new Rotation3d(Math.toRadians(0), Math.toRadians(0), Math.toRadians(30)),
-        new Translation3d(Units.inchesToMeters(9.25), Units.inchesToMeters(-10.125), Units.inchesToMeters(18)),
-        VecBuilder.fill(.9, .9, 6), VecBuilder.fill(0.5, 0.5, 1));
-
-    // RIGHT_CAM("top", new Rotation3d(0, Math.toRadians(0), Math.toRadians(180)),
-    //     new Translation3d(Units.inchesToMeters(-7), Units.inchesToMeters(0), Units.inchesToMeters(14.75)),
-    //     VecBuilder.fill(1.8, 1.8, 8), VecBuilder.fill(0.5, 0.5, 1));
-    // RIGHT_CAM("top1",
-    // new Rotation3d(0, Math.toRadians(-24.094), Math.toRadians(-30)),
-    // // new Translation3d(Units.inchesToMeters(12.056),
-    // Units.inchesToMeters(-10.981), Units.inchesToMeters(8.44)),
-    // VecBuilder.fill(4, 4, 8), VecBuilder.fill(0.5, 0.5, 1));
-    /**
-     * Left Camera
-     */
-    // LEFT_CAM("left",
-    // new Rotation3d(0, Math.toRadians(-24.094), Math.toRadians(30)),
-    // new Translation3d(Units.inchesToMeters(12.056),
-    // Units.inchesToMeters(10.981),
-    // Units.inchesToMeters(8.44)),
-    // VecBuilder.fill(4, 4, 8), VecBuilder.fill(0.5, 0.5, 1)),
-    // /**
-    // * Right Camera
-    // */
-    // RIGHT_CAM("right",
-    // new Rotation3d(0, Math.toRadians(-24.094), Math.toRadians(-30)),
-    // new Translation3d(Units.inchesToMeters(12.056),
-    // Units.inchesToMeters(-10.981),
-    // Units.inchesToMeters(8.44)),
-    // VecBuilder.fill(4, 4, 8), VecBuilder.fill(0.5, 0.5, 1)),
-    // /**
-    // * Center Camera
-    // */
-    // CENTER_CAM("center",
-    // new Rotation3d(0, Units.degreesToRadians(18), 0),
-    // new Translation3d(Units.inchesToMeters(-4.628),
-    // Units.inchesToMeters(-10.687),
-    // Units.inchesToMeters(16.129)),
-
-    /**
-     * Latency alert to use when high latency is detected.
-     */
-    public final Alert latencyAlert;
-    /**
-     * Camera instance for comms.
-     */
-    public final PhotonCamera camera;
-    /**
-     * Pose estimator for camera.
-     */
-    public final PhotonPoseEstimator poseEstimator;
-    /**
-     * Standard Deviation for single tag readings for pose estimation.
-     */
-    private final Matrix<N3, N1> singleTagStdDevs;
-    /**
-     * Standard deviation for multi-tag readings for pose estimation.
-     */
-    private final Matrix<N3, N1> multiTagStdDevs;
-    /**
-     * Transform of the camera rotation and translation relative to the center of
-     * the robot
-     */
-    private final Transform3d robotToCamTransform;
-    /**
-     * Current standard deviations used.
-     */
-    public Matrix<N3, N1> curStdDevs;
-    /**
-     * Estimated robot pose.
-     */
-    public Optional<EstimatedRobotPose> estimatedRobotPose = Optional.empty();
-
-    /**
-     * Simulated camera instance which only exists during simulations.
-     */
-    public PhotonCameraSim cameraSim;
-    /**
-     * Results list to be updated periodically and cached to avoid unnecessary
-     * queries.
-     */
-    public List<PhotonPipelineResult> resultsList = new ArrayList<>();
-    /**
-     * Last read from the camera timestamp to prevent lag due to slow data fetches.
-     */
-    private double lastReadTimestamp = Microseconds.of(NetworkTablesJNI.now()).in(Seconds);
-
-    /**
-     * Construct a Photon Camera class with help. Standard deviations are fake
-     * values, experiment and determine
-     * estimation noise on an actual robot.
-     *
-     * @param name                  Name of the PhotonVision camera found in the PV
-     *                              UI.
-     * @param robotToCamRotation    {@link Rotation3d} of the camera.
-     * @param robotToCamTranslation {@link Translation3d} relative to the center of
-     *                              the robot.
-     * @param singleTagStdDevs      Single AprilTag standard deviations of estimated
-     *                              poses from the camera.
-     * @param multiTagStdDevsMatrix Multi AprilTag standard deviations of estimated
-     *                              poses from the camera.
-     */
-    Cameras(String name, Rotation3d robotToCamRotation, Translation3d robotToCamTranslation,
-        Matrix<N3, N1> singleTagStdDevs, Matrix<N3, N1> multiTagStdDevsMatrix) {
-      latencyAlert = new Alert("'" + name + "' Camera is experiencing high latency.", AlertType.kWarning);
-
-      camera = new PhotonCamera(name);
-
-      // https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html
-      robotToCamTransform = new Transform3d(robotToCamTranslation, robotToCamRotation);
-
-      poseEstimator = new PhotonPoseEstimator(Vision.fieldLayout,
-          PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR,
-          robotToCamTransform);
-      poseEstimator.setMultiTagFallbackStrategy(PoseStrategy.LOWEST_AMBIGUITY);
-
-      this.singleTagStdDevs = singleTagStdDevs;
-      this.multiTagStdDevs = multiTagStdDevsMatrix;
-
-      if (Robot.isSimulation()) {
-        SimCameraProperties cameraProp = new SimCameraProperties();
-        // A 640 x 480 camera with a 100 degree diagonal FOV.
-        cameraProp.setCalibration(960, 720, Rotation2d.fromDegrees(100));
-        // Approximate detection noise with average and standard deviation error in
-        // pixels.
-        cameraProp.setCalibError(0.25, 0.08);
-        // Set the camera image capture framerate (Note: this is limited by robot loop
-        // rate).
-        cameraProp.setFPS(30);
-        // The average and standard deviation in milliseconds of image data latency.
-        cameraProp.setAvgLatencyMs(35);
-        cameraProp.setLatencyStdDevMs(5);
-
-        cameraSim = new PhotonCameraSim(camera, cameraProp);
-        cameraSim.enableDrawWireframe(true);
-      }
-    }
-
-    /**
-     * Add camera to {@link VisionSystemSim} for simulated photon vision.
-     *
-     * @param systemSim {@link VisionSystemSim} to use.
-     */
-    public void addToVisionSim(VisionSystemSim systemSim) {
-      if (Robot.isSimulation()) {
-        systemSim.addCamera(cameraSim, robotToCamTransform);
-      }
-    }
-
-    /**
-     * Get the result with the least ambiguity from the best tracked target within
-     * the Cache. This may not be the most
-     * recent result!
-     *
-     * @return The result in the cache with the least ambiguous best tracked target.
-     *         This is not the most recent result!
-     */
-    public Optional<PhotonPipelineResult> getBestResult() {
-      if (resultsList.isEmpty()) {
-        return Optional.empty();
-      }
-
-      PhotonPipelineResult bestResult = resultsList.get(0);
-      double amiguity = bestResult.getBestTarget().getPoseAmbiguity();
-      double currentAmbiguity = 0;
-      for (PhotonPipelineResult result : resultsList) {
-        currentAmbiguity = result.getBestTarget().getPoseAmbiguity();
-        if (currentAmbiguity < amiguity && currentAmbiguity >= 0) {
-          bestResult = result;
-          amiguity = currentAmbiguity;
-        }
-      }
-      return Optional.of(bestResult);
-    }
-
-    /**
-     * Get the latest result from the current cache.
-     *
-     * @return Empty optional if nothing is found. Latest result if something is
-     *         there.
-     */
-    public Optional<PhotonPipelineResult> getLatestResult() {
-      return resultsList.isEmpty() ? Optional.empty() : Optional.of(resultsList.get(0));
-    }
-
-    /**
-     * Get the estimated robot pose. Updates the current robot pose estimation,
-     * standard deviations, and flushes the
-     * cache of results.
-     *
-     * @return Estimated pose.
-     */
-    public Optional<EstimatedRobotPose> getEstimatedGlobalPose() {
-      updateUnreadResults();
-      return estimatedRobotPose;
-    }
-
-    /**
-     * Update the latest results, cached with a maximum refresh rate of 1req/15ms.
-     * Sorts the list by timestamp.
-     */
-    private void updateUnreadResults() {
-      double mostRecentTimestamp = resultsList.isEmpty() ? 0.0 : resultsList.get(0).getTimestampSeconds();
-      double currentTimestamp = Microseconds.of(NetworkTablesJNI.now()).in(Seconds);
-      double debounceTime = Milliseconds.of(15).in(Seconds);
-      for (PhotonPipelineResult result : resultsList) {
-        mostRecentTimestamp = Math.max(mostRecentTimestamp, result.getTimestampSeconds());
-      }
-      if ((resultsList.isEmpty() || (currentTimestamp - mostRecentTimestamp >= debounceTime)) &&
-          (currentTimestamp - lastReadTimestamp) >= debounceTime) {
-        resultsList = Robot.isReal() ? camera.getAllUnreadResults() : cameraSim.getCamera().getAllUnreadResults();
-        lastReadTimestamp = currentTimestamp;
-        resultsList.sort((PhotonPipelineResult a, PhotonPipelineResult b) -> {
-          return a.getTimestampSeconds() >= b.getTimestampSeconds() ? 1 : -1;
-        });
-        if (!resultsList.isEmpty()) {
-          updateEstimatedGlobalPose();
-        }
-      }
-    }
-
-    /**
-     * The latest estimated robot pose on the field from vision data. This may be
-     * empty. This should only be called once
-     * per loop.
-     *
-     * <p>
-     * Also includes updates for the standard deviations, which can (optionally) be
-     * retrieved with
-     * {@link Cameras#updateEstimationStdDevs}
-     *
-     * @return An {@link EstimatedRobotPose} with an estimated pose, estimate
-     *         timestamp, and targets used for
-     *         estimation.
-     */
-    private void updateEstimatedGlobalPose() {
-      Optional<EstimatedRobotPose> visionEst = Optional.empty();
-      for (var change : resultsList) {
-        visionEst = poseEstimator.update(change);
-        updateEstimationStdDevs(visionEst, change.getTargets());
-      }
-      estimatedRobotPose = visionEst;
-    }
-
-    /**
-     * Calculates new standard deviations This algorithm is a heuristic that creates
-     * dynamic standard deviations based
-     * on number of tags, estimation strategy, and distance from the tags.
-     *
-     * @param estimatedPose The estimated pose to guess standard deviations for.
-     * @param targets       All targets in this camera frame
-     */
-    public void updateEstimationStdDevs(
-        Optional<EstimatedRobotPose> estimatedPose, List<PhotonTrackedTarget> targets) {
-
-      if (estimatedPose.isEmpty()) {
-        m_ledSubsystem.setLEDsRed();
-        // No pose input. Default to single-tag std devs
-        curStdDevs = singleTagStdDevs;
-      } else {
-
-        // Pose present. Start running Heuristic
-        var estStdDevs = singleTagStdDevs;
-        int numTags = 0;
-        double avgDist = 0;
-        m_ledSubsystem.setLedsGreen();
-
-        // Precalculation - see how many tags we found, and calculate an
-        // average-distance metric
-        for (var tgt : targets) {
-          var tagPose = poseEstimator.getFieldTags().getTagPose(tgt.getFiducialId());
-
-          if (tagPose.isEmpty() || tgt.poseAmbiguity > Constants.MAXIMUM_AMBIGUITY) {
-            continue;
-          }
-          numTags++;
-          avgDist += tagPose
-              .get()
-              .toPose2d()
-              .getTranslation()
-              .getDistance(estimatedPose.get().estimatedPose.toPose2d().getTranslation());
-        }
-
-        if (numTags == 0) {
-
-          // No tags visible. Default to single-tag std devs
-          curStdDevs = singleTagStdDevs;
-        } else {
-          // One or more tags visible, run the full heuristic.
-          avgDist /= numTags;
-          // Decrease std devs if multiple targets are visible
-          if (numTags > 1) {
-            estStdDevs = multiTagStdDevs;
-          }
-          // Increase std devs based on (average) distance
-          if (numTags == 1 && avgDist > 4) {
-            estStdDevs = VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
-          } else {
-            estStdDevs = estStdDevs.times(1 + (avgDist * avgDist / 30));
-          }
-          curStdDevs = estStdDevs;
-        }
-      }
-    }
-
   }
 
 }

--- a/src/main/java/frc/robot/subsystems/swervedrive/VisionCamera.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/VisionCamera.java
@@ -1,0 +1,309 @@
+package frc.robot.subsystems.swervedrive;
+
+import static edu.wpi.first.units.Units.Microseconds;
+import static edu.wpi.first.units.Units.Milliseconds;
+import static edu.wpi.first.units.Units.Seconds;
+
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.networktables.NetworkTablesJNI;
+import edu.wpi.first.wpilibj.Alert;
+import edu.wpi.first.wpilibj.Alert.AlertType;
+import frc.robot.Constants;
+import frc.robot.Robot;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.photonvision.EstimatedRobotPose;
+import org.photonvision.PhotonCamera;
+import org.photonvision.PhotonPoseEstimator;
+import org.photonvision.PhotonPoseEstimator.PoseStrategy;
+import org.photonvision.simulation.PhotonCameraSim;
+import org.photonvision.simulation.SimCameraProperties;
+import org.photonvision.simulation.VisionSystemSim;
+import org.photonvision.targeting.PhotonPipelineResult;
+import org.photonvision.targeting.PhotonTrackedTarget;
+import frc.robot.subsystems.led.LED;
+
+public class VisionCamera {
+  /**
+   * Latency alert to use when high latency is detected.
+   */
+  public final Alert latencyAlert;
+  /**
+   * Camera instance for comms.
+   */
+  public final PhotonCamera camera;
+  /**
+   * Pose estimator for camera.
+   */
+  public final PhotonPoseEstimator poseEstimator;
+  /**
+   * Standard Deviation for single tag readings for pose estimation.
+   */
+  private final Matrix<N3, N1> singleTagStdDevs;
+  /**
+   * Standard deviation for multi-tag readings for pose estimation.
+   */
+  private final Matrix<N3, N1> multiTagStdDevs;
+  /**
+   * Transform of the camera rotation and translation relative to the center of
+   * the robot
+   */
+  private final Transform3d robotToCamTransform;
+  /**
+   * Current standard deviations used.
+   */
+  public Matrix<N3, N1> curStdDevs;
+  /**
+   * Estimated robot pose.
+   */
+  public Optional<EstimatedRobotPose> estimatedRobotPose = Optional.empty();
+
+  /**
+   * Simulated camera instance which only exists during simulations.
+   */
+  public PhotonCameraSim cameraSim;
+  /**
+   * Results list to be updated periodically and cached to avoid unnecessary
+   * queries.
+   */
+  public List<PhotonPipelineResult> resultsList = new ArrayList<>();
+  /**
+   * Last read from the camera timestamp to prevent lag due to slow data fetches.
+   */
+  private double lastReadTimestamp = Microseconds.of(NetworkTablesJNI.now()).in(Seconds);
+
+  /**
+   * Instance of the LED subsystem created in RobotContainer.
+   * We keep passing it down so there's only one instance
+   * and we can track state
+   */
+  public static LED m_ledSubsystem;
+
+  /**
+   * Construct a Photon Camera class with help. Standard deviations are fake
+   * values, experiment and determine
+   * estimation noise on an actual robot.
+   *
+   * @param name                  Name of the PhotonVision camera found in the PV
+   *                              UI.
+   * @param robotToCamRotation    {@link Rotation3d} of the camera.
+   * @param robotToCamTranslation {@link Translation3d} relative to the center of
+   *                              the robot.
+   * @param singleTagStdDevs      Single AprilTag standard deviations of estimated
+   *                              poses from the camera.
+   * @param multiTagStdDevsMatrix Multi AprilTag standard deviations of estimated
+   *                              poses from the camera.
+   */
+  public VisionCamera(String name, Rotation3d robotToCamRotation, Translation3d robotToCamTranslation,
+      Matrix<N3, N1> singleTagStdDevs, Matrix<N3, N1> multiTagStdDevsMatrix, LED ledSubsystem) {
+    latencyAlert = new Alert("'" + name + "' Camera is experiencing high latency.", AlertType.kWarning);
+
+    camera = new PhotonCamera(name);
+
+    // https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html
+    robotToCamTransform = new Transform3d(robotToCamTranslation, robotToCamRotation);
+
+    poseEstimator = new PhotonPoseEstimator(Vision.fieldLayout,
+        PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR,
+        robotToCamTransform);
+    poseEstimator.setMultiTagFallbackStrategy(PoseStrategy.LOWEST_AMBIGUITY);
+
+    this.singleTagStdDevs = singleTagStdDevs;
+    this.multiTagStdDevs = multiTagStdDevsMatrix;
+    m_ledSubsystem = ledSubsystem;
+
+    if (Robot.isSimulation()) {
+      SimCameraProperties cameraProp = new SimCameraProperties();
+      // A 640 x 480 camera with a 100 degree diagonal FOV.
+      cameraProp.setCalibration(960, 720, Rotation2d.fromDegrees(100));
+      // Approximate detection noise with average and standard deviation error in
+      // pixels.
+      cameraProp.setCalibError(0.25, 0.08);
+      // Set the camera image capture framerate (Note: this is limited by robot loop
+      // rate).
+      cameraProp.setFPS(30);
+      // The average and standard deviation in milliseconds of image data latency.
+      cameraProp.setAvgLatencyMs(35);
+      cameraProp.setLatencyStdDevMs(5);
+
+      cameraSim = new PhotonCameraSim(camera, cameraProp);
+      cameraSim.enableDrawWireframe(true);
+    }
+  }
+
+  /**
+   * Add camera to {@link VisionSystemSim} for simulated photon vision.
+   *
+   * @param systemSim {@link VisionSystemSim} to use.
+   */
+  public void addToVisionSim(VisionSystemSim systemSim) {
+    if (Robot.isSimulation()) {
+      systemSim.addCamera(cameraSim, robotToCamTransform);
+    }
+  }
+
+  /**
+   * Get the result with the least ambiguity from the best tracked target within
+   * the Cache. This may not be the most
+   * recent result!
+   *
+   * @return The result in the cache with the least ambiguous best tracked target.
+   *         This is not the most recent result!
+   */
+  public Optional<PhotonPipelineResult> getBestResult() {
+    if (resultsList.isEmpty()) {
+      return Optional.empty();
+    }
+
+    PhotonPipelineResult bestResult = resultsList.get(0);
+    double amiguity = bestResult.getBestTarget().getPoseAmbiguity();
+    double currentAmbiguity = 0;
+    for (PhotonPipelineResult result : resultsList) {
+      currentAmbiguity = result.getBestTarget().getPoseAmbiguity();
+      if (currentAmbiguity < amiguity && currentAmbiguity >= 0) {
+        bestResult = result;
+        amiguity = currentAmbiguity;
+      }
+    }
+    return Optional.of(bestResult);
+  }
+
+  /**
+   * Get the latest result from the current cache.
+   *
+   * @return Empty optional if nothing is found. Latest result if something is
+   *         there.
+   */
+  public Optional<PhotonPipelineResult> getLatestResult() {
+    return resultsList.isEmpty() ? Optional.empty() : Optional.of(resultsList.get(0));
+  }
+
+  /**
+   * Get the estimated robot pose. Updates the current robot pose estimation,
+   * standard deviations, and flushes the
+   * cache of results.
+   *
+   * @return Estimated pose.
+   */
+  public Optional<EstimatedRobotPose> getEstimatedGlobalPose() {
+    updateUnreadResults();
+    return estimatedRobotPose;
+  }
+
+  /**
+   * Update the latest results, cached with a maximum refresh rate of 1req/15ms.
+   * Sorts the list by timestamp.
+   */
+  private void updateUnreadResults() {
+    double mostRecentTimestamp = resultsList.isEmpty() ? 0.0 : resultsList.get(0).getTimestampSeconds();
+    double currentTimestamp = Microseconds.of(NetworkTablesJNI.now()).in(Seconds);
+    double debounceTime = Milliseconds.of(15).in(Seconds);
+    for (PhotonPipelineResult result : resultsList) {
+      mostRecentTimestamp = Math.max(mostRecentTimestamp, result.getTimestampSeconds());
+    }
+    if ((resultsList.isEmpty() || (currentTimestamp - mostRecentTimestamp >= debounceTime)) &&
+        (currentTimestamp - lastReadTimestamp) >= debounceTime) {
+      resultsList = Robot.isReal() ? camera.getAllUnreadResults() : cameraSim.getCamera().getAllUnreadResults();
+      lastReadTimestamp = currentTimestamp;
+      resultsList.sort((PhotonPipelineResult a, PhotonPipelineResult b) -> {
+        return a.getTimestampSeconds() >= b.getTimestampSeconds() ? 1 : -1;
+      });
+      if (!resultsList.isEmpty()) {
+        updateEstimatedGlobalPose();
+      }
+    }
+  }
+
+  /**
+   * The latest estimated robot pose on the field from vision data. This may be
+   * empty. This should only be called once
+   * per loop.
+   *
+   * <p>
+   * Also includes updates for the standard deviations, which can (optionally) be
+   * retrieved with
+   * {@link Cameras#updateEstimationStdDevs}
+   *
+   * @return An {@link EstimatedRobotPose} with an estimated pose, estimate
+   *         timestamp, and targets used for
+   *         estimation.
+   */
+  private void updateEstimatedGlobalPose() {
+    Optional<EstimatedRobotPose> visionEst = Optional.empty();
+    for (var change : resultsList) {
+      visionEst = poseEstimator.update(change);
+      updateEstimationStdDevs(visionEst, change.getTargets());
+    }
+    estimatedRobotPose = visionEst;
+  }
+
+  /**
+   * Calculates new standard deviations This algorithm is a heuristic that creates
+   * dynamic standard deviations based
+   * on number of tags, estimation strategy, and distance from the tags.
+   *
+   * @param estimatedPose The estimated pose to guess standard deviations for.
+   * @param targets       All targets in this camera frame
+   */
+  public void updateEstimationStdDevs(
+      Optional<EstimatedRobotPose> estimatedPose, List<PhotonTrackedTarget> targets) {
+
+    if (estimatedPose.isEmpty()) {
+      m_ledSubsystem.setLEDsRed();
+      // No pose input. Default to single-tag std devs
+      curStdDevs = singleTagStdDevs;
+    } else {
+
+      // Pose present. Start running Heuristic
+      var estStdDevs = singleTagStdDevs;
+      int numTags = 0;
+      double avgDist = 0;
+      m_ledSubsystem.setLedsGreen();
+
+      // Precalculation - see how many tags we found, and calculate an
+      // average-distance metric
+      for (var tgt : targets) {
+        var tagPose = poseEstimator.getFieldTags().getTagPose(tgt.getFiducialId());
+
+        if (tagPose.isEmpty() || tgt.poseAmbiguity > Constants.MAXIMUM_AMBIGUITY) {
+          continue;
+        }
+        numTags++;
+        avgDist += tagPose
+            .get()
+            .toPose2d()
+            .getTranslation()
+            .getDistance(estimatedPose.get().estimatedPose.toPose2d().getTranslation());
+      }
+
+      if (numTags == 0) {
+
+        // No tags visible. Default to single-tag std devs
+        curStdDevs = singleTagStdDevs;
+      } else {
+        // One or more tags visible, run the full heuristic.
+        avgDist /= numTags;
+        // Decrease std devs if multiple targets are visible
+        if (numTags > 1) {
+          estStdDevs = multiTagStdDevs;
+        }
+        // Increase std devs based on (average) distance
+        if (numTags == 1 && avgDist > 4) {
+          estStdDevs = VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
+        } else {
+          estStdDevs = estStdDevs.times(1 + (avgDist * avgDist / 30));
+        }
+        curStdDevs = estStdDevs;
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Refactor vision to not use an enum when handling multiple cameras. The goal is to fi a bug where restarting/rebooting the robot caused vision loops to stop functioning as expected. 

This code works in the simulation, but without a way to test for loop overruns on the bot and the LEDs we should test it in this branch before merging to main. 

Not sure how to do that? Here's how! Git style 😎 

First do a pull from the main branch to be sure all code is up to date
```
git pull
```

Next fetch the branch so your local computer knows it exists 
```
git fetch origin refactor_vision_remove_enum
```

Then checkout the branch so you can load it to the bot without changing the code on main
```
git checkout refactor_vision_remove_enum
```

If the code works hooray! Then you can merge this pull request, `git checkout main` to get back to the right branch and `git pull` to get the changes. This will keep everything synced up and happy 